### PR TITLE
Fix syntax error in validator

### DIFF
--- a/tools/validator/upps_validator.py
+++ b/tools/validator/upps_validator.py
@@ -420,5 +420,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-                    if abs(ability['level']


### PR DESCRIPTION
## Summary
- remove stray line at end of `upps_validator.py`

## Testing
- `python3 -m py_compile tools/validator/upps_validator.py`

------
https://chatgpt.com/codex/tasks/task_e_6843dbb3b5ac8327942feaf9be428232