### PR TITLE
Fix README paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ UPPSでは、UPPS標準に基づく人格データセットを「UPPSペルソ�
 #### ✅ 利用可能なドキュメント
 
 - [基本テンプレート](./prompting/templates/basic_template.md): 基本的なUPPSペルソナプロンプトテンプレート
-- [状態管理テンプレート](./prompting/templates/state_update.md): 感情状態の更新を含むテンプレート  
-- [記憶トリガーテンプレート](./prompting/templates/memory_trigger.md): 記憶想起機能を含むテンプレート
-- [サンプルペルソナ - レイチェル](./examples/profiles/rachel_bladerunner.md): ブレードランナーのキャラクター例
+- [サンプルペルソナ - レイチェル](./persona_lib/rachel_bladerunner.md): ブレードランナーのキャラクター例
 
 #### 📋 開発予定（プロンプト主導型）
 
@@ -149,7 +147,7 @@ upps/
 
 ```
 prompting/                         # プロンプト主導型（開発中）  
-├── examples/                       
+├── example/                       
 │   ├── conversation_example.md    # 会話例 🚧  
 │   └── session_management.md      # セッション管理例 🚧  
 │  

--- a/project_todo/upps_project_management.md
+++ b/project_todo/upps_project_management.md
@@ -28,7 +28,7 @@ upps/
 │   │   ├── basic_template.md      # 基本テンプレート
 │   │   ├── state_update.md        # 状態更新用テンプレート
 │   │   └── memory_trigger.md      # 記憶トリガー用テンプレート
-│   └── examples/                  # プロンプト使用例
+│   └── example/                  # プロンプト使用例
 │       ├── conversation_example.md # 会話例
 │       └── session_management.md   # セッション管理例
 │
@@ -66,8 +66,8 @@ upps/
 - [x] 記憶トリガーテンプレート (`prompting/templates/memory_trigger.md`) を作成
 - [ ] 直接プロンプト利用ガイド (`upps-direct-prompting-guide-revised.md`) を整理
 - [ ] 整理したガイドを `prompting/direct_prompting_guide.md` に移行
-- [ ] 会話例 (`upps-conversation-example-revised.md`) を `prompting/examples/conversation_example.md` に移行
-- [ ] セッション管理の例を作成して `prompting/examples/session_management.md` に配置
+- [ ] 会話例 (`upps-conversation-example-revised.md`) を `prompting/example/conversation_example.md` に移行
+- [ ] セッション管理の例を作成して `prompting/example/session_management.md` に配置
 
 ### 3. 実装ガイドの整理
 

--- a/prompting/README.md
+++ b/prompting/README.md
@@ -16,7 +16,7 @@ prompting/
 │   ├── anthropic_claude.md       # Anthropic Claude用テンプレート
 │   ├── google_gemini.md          # Google Gemini用テンプレート
 │   └── meta_llama.md             # Meta Llama用テンプレート
-└── examples/
+└── example/
     └── example_conversation.md   # 対話例
 ```
 
@@ -70,7 +70,7 @@ personal_info:
 # 対話を開始
 ```
 
-詳細な使用例については [examples/example_conversation.md](./examples/example_conversation.md) を参照してください。
+詳細な使用例については [example/example_conversation.md](./example/example_conversation.md) を参照してください。
 
 ---
 


### PR DESCRIPTION
## Summary
- remove unavailable templates from README
- fix persona link to `persona_lib`
- point to `prompting/example` directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843de71b67c832791c858310aa94213