### PR TITLE
Add Jest tests and CI workflow

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,0 +1,26 @@
+name: Node.js CI
+
+on:
+  push:
+    paths:
+      - '**.js'
+      - package.json
+      - jest.config.js
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '**.js'
+      - package.json
+      - jest.config.js
+      - '.github/workflows/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install --no-progress
+      - run: npm test --silent

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  testEnvironment: 'node',
+  verbose: true,
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "upps_developing",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+  },
+  "devDependencies": {
+    "jest": "^29.6.0"
+  }
+}

--- a/tools/editor/upps_editor/tests/EventBus.test.js
+++ b/tools/editor/upps_editor/tests/EventBus.test.js
@@ -1,0 +1,36 @@
+import { jest } from '@jest/globals';
+import { EventBus } from '../js/core/EventBus.js';
+
+describe('EventBus', () => {
+  test('handlers receive emitted events', () => {
+    const bus = new EventBus({ enableLogging: false });
+    const handler = jest.fn();
+    bus.on('test:event', handler);
+
+    bus.emit('test:event', { value: 42 });
+    expect(handler).toHaveBeenCalledWith({ value: 42 });
+  });
+
+  test('once handler triggers only once', () => {
+    const bus = new EventBus({ enableLogging: false });
+    const handler = jest.fn();
+    bus.once('single', handler);
+
+    bus.emit('single');
+    bus.emit('single');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('middleware intercepts events', () => {
+    const bus = new EventBus({ enableLogging: false });
+    const calls = [];
+    bus.use((event, data, next) => {
+      calls.push({ event, data });
+      next();
+    });
+
+    bus.emit('mw:event', 123);
+    expect(calls).toEqual([{ event: 'mw:event', data: 123 }]);
+  });
+});

--- a/tools/editor/upps_editor/tests/ModuleRegistry.test.js
+++ b/tools/editor/upps_editor/tests/ModuleRegistry.test.js
@@ -1,0 +1,37 @@
+import { jest } from '@jest/globals';
+import { ModuleRegistry } from '../js/core/ModuleRegistry.js';
+import { EventBus } from '../js/core/EventBus.js';
+import { StateManager } from '../js/core/StateManager.js';
+
+global.window = { addEventListener: jest.fn() };
+const localStore = {};
+Object.defineProperty(global, 'localStorage', {
+  value: {
+    setItem: (k, v) => { localStore[k] = v; },
+    getItem: (k) => localStore[k] || null,
+    removeItem: (k) => { delete localStore[k]; },
+  },
+});
+
+describe('ModuleRegistry', () => {
+  test('register and initialize modules respecting dependencies', async () => {
+    const bus = new EventBus({ enableLogging: false });
+    const sm = new StateManager({ persistence: false, autoSave: false });
+    const registry = new ModuleRegistry(bus, sm);
+
+    const modA = { initialize: jest.fn(), start: jest.fn() };
+    const modB = { dependencies: ['A'], initialize: jest.fn(), start: jest.fn() };
+
+    registry.register('A', modA);
+    registry.register('B', modB);
+
+    await registry.initialize();
+    expect(modA.initialize).toHaveBeenCalled();
+    expect(modB.initialize).toHaveBeenCalled();
+    expect(registry.initializationOrder).toEqual(['A', 'B']);
+
+    await registry.start();
+    expect(modA.start).toHaveBeenCalled();
+    expect(modB.start).toHaveBeenCalled();
+  });
+});

--- a/tools/editor/upps_editor/tests/StateManager.test.js
+++ b/tools/editor/upps_editor/tests/StateManager.test.js
@@ -1,0 +1,42 @@
+import { jest } from '@jest/globals';
+import { StateManager } from '../js/core/StateManager.js';
+
+global.window = {
+  addEventListener: jest.fn(),
+};
+
+const localStore = {};
+Object.defineProperty(global, 'localStorage', {
+  value: {
+    setItem: (k, v) => {
+      localStore[k] = v;
+    },
+    getItem: (k) => localStore[k] || null,
+    removeItem: (k) => {
+      delete localStore[k];
+    },
+  },
+});
+
+describe('StateManager', () => {
+  test('setState and getState work', () => {
+    const sm = new StateManager({ persistence: false, autoSave: false });
+    sm.setState('user.name', 'Alice');
+    expect(sm.getState('user.name')).toBe('Alice');
+  });
+
+  test('subscribe receives updates', () => {
+    const sm = new StateManager({ persistence: false, autoSave: false });
+    const cb = jest.fn();
+    sm.subscribe('count', cb);
+    sm.setState('count', 1);
+    expect(cb).toHaveBeenCalledWith(1);
+  });
+
+  test('deleteState removes value', () => {
+    const sm = new StateManager({ persistence: false, autoSave: false });
+    sm.setState('tmp.val', 10);
+    sm.deleteState('tmp.val');
+    expect(sm.getState('tmp.val')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- create test setup using Jest
- add tests for `StateManager`, `EventBus`, and `ModuleRegistry`
- add `jest` configuration and npm script
- run tests in GitHub Actions workflow

## Testing
- `npm install --no-progress`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843ecafe8248327845448ed22d0b50d