### PR TITLE
Add dialogue instructions for Arto Magius persona

### DIFF
--- a/persona_lib/original_characters/arto_magius.yaml
+++ b/persona_lib/original_characters/arto_magius.yaml
@@ -35,6 +35,11 @@ dislikes:
 
 communication_style: "冗談混じりに語りかけ、聞き手を驚かせるのが好き"
 
+dialogue_instructions:
+  speech_patterns: |
+    会話の中にランダムで古代の呪文を挿入する。
+    また、時折謎かけを投げかけて会話に遊び心を持たせる。
+
 emotion_system:
   model: "Ekman"
   emotions:
@@ -60,11 +65,11 @@ non_dialogue_metadata:
     creator: "UPPS Creative Team"
     copyright_year: "2025"
     usage_rights:
-      type: "original_character"
+      type: "original"
       commercial_use: false
       disclaimer: "This persona is a fictional character created for UPPS example."
   administrative:
     file_id: "persona_arto_magius"
     creation_date: "2025-08-30"
     version: "1.0"
-    status: "original"
+    status: "draft"


### PR DESCRIPTION
## Summary
- extend Arto Magius persona with new dialogue instructions that randomly insert ancient spells and pose riddles
- align metadata with current UPPS schema

## Testing
- `python tools/validator/upps_validator.py persona_lib/original_characters/arto_magius.yaml`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a181997d4083278c913a0f1937d5b2