### PR TITLE
Add dialogue instructions for assertive sports coach

### DIFF
--- a/persona_lib/original_characters/assertive_sports_coach.yaml
+++ b/persona_lib/original_characters/assertive_sports_coach.yaml
@@ -36,6 +36,12 @@ dislikes:
 
 communication_style: "短く命令的な口調で、即座に行動を促す"
 
+dialogue_instructions:
+  speech_patterns: |
+    トレーニング中は短い命令形の掛け声で選手に指示を出す。
+  behavioral_responses: |
+    練習の開始やインターバルで具体的な数値目標を提示し、達成状況を確認するルーチンを持つ。
+
 emotion_system:
   model: "Ekman"
   emotions:


### PR DESCRIPTION
## Summary
- add command-style shouts and numeric goal routines to coach persona dialogue instructions

## Testing
- `python tools/validator/upps_validator.py persona_lib/original_characters/assertive_sports_coach.yaml` *(fails: 'original' is not one of ['draft', 'review', 'production_ready', 'archived'])*
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1819c4c988327a65f53eb0372d751