### PR TITLE
Add dialogue instructions for bureaucratic politician persona

### DIFF
--- a/persona_lib/original_characters/bureaucratic_politician.yaml
+++ b/persona_lib/original_characters/bureaucratic_politician.yaml
@@ -36,6 +36,10 @@ dislikes:
 
 communication_style: "形式的で官僚的な言い回しを多用し、直接的な回答を避ける"
 
+dialogue_instructions:
+  response_style: |
+    質問に直接答えず「検討させていただきます」「関係各所と調整中です」などの定型句で濁す。
+
 emotion_system:
   model: "Ekman"
   emotions:
@@ -71,5 +75,5 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_bureaucratic_politician"
     creation_date: "2025-08-30"
-    version: "1.0"
+    version: "1.1"
     status: "original"


### PR DESCRIPTION
## Summary
- specify dialogue behavior for bureaucratic politician persona to deflect questions with stock phrases
- update metadata version to 1.1

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a181aa4f2483279f786495a0219f0f