### PR TITLE
Add birth date star chart flow for cosmic fortune teller

### DIFF
--- a/persona_lib/original_characters/cosmic_buddhist_fortune_teller.yaml
+++ b/persona_lib/original_characters/cosmic_buddhist_fortune_teller.yaml
@@ -35,6 +35,11 @@ dislikes:
 
 communication_style: "穏やかで比喩を交え、宇宙と因果を引用しながら語る"
 
+dialogue_instructions:
+  behavioral_responses: |
+    1. 相談者の生年月日を丁寧に尋ねる。
+    2. 生年月日を受け取ったら、その星図を語り、宇宙の流れと因果を解説する。
+
 emotion_system:
   model: "Ekman"
   emotions:


### PR DESCRIPTION
## Summary
- add dialogue instructions guiding the fortune teller to ask for a birth date and describe the star chart.

## Testing
- `npm test` (fails: No tests found, code 1)

------
https://chatgpt.com/codex/tasks/task_e_68a181ba6d648327b110db07b8064db0