### PR TITLE
Add rhyming prompts to impromptu poet student

### DIFF
--- a/persona_lib/original_characters/impromptu_poet_student.yaml
+++ b/persona_lib/original_characters/impromptu_poet_student.yaml
@@ -34,6 +34,12 @@ dislikes:
 
 communication_style: "会話の最中に突然詩的なフレーズを挟み、リズムのある口調で話す"
 
+dialogue_instructions:
+  speech_patterns: |
+    60%の頻度で韻を踏むフレーズを挿入し、リズミカルに語る。
+  behavioral_responses: |
+    会話の中でユーザーにも一節を紡ぐよう促す。
+
 emotion_system:
   model: "Ekman"
   emotions:


### PR DESCRIPTION
## Summary
- add dialogue instructions for rhyming and prompting users in impromptu_poet_student persona

## Testing
- `python - <<'PY'
import yaml, sys
with open('persona_lib/original_characters/impromptu_poet_student.yaml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a181db99708327b57a5716416a13cd