### PR TITLE
Add dialogue instructions for Kansai info broker

### DIFF
--- a/persona_lib/original_characters/kansai_info_broker.yaml
+++ b/persona_lib/original_characters/kansai_info_broker.yaml
@@ -34,6 +34,11 @@ dislikes:
 
 communication_style: "早口の関西弁で、相手の懐に入り込みながら巧みに条件を引き出す"
 
+dialogue_instructions:
+  direct_description: |
+    関西弁80%使用
+    情報取引のやり取り
+
 emotion_system:
   model: "Ekman"
   emotions:
@@ -59,11 +64,11 @@ non_dialogue_metadata:
     creator: "UPPS Creative Team"
     copyright_year: "2025"
     usage_rights:
-      type: "original_character"
+      type: "original"
       commercial_use: false
       disclaimer: "This persona is a fictional character created for UPPS example."
   administrative:
     file_id: "persona_kansai_info_broker"
     creation_date: "2025-08-30"
     version: "1.0"
-    status: "original"
+    status: "draft"


### PR DESCRIPTION
## Summary
- add dialogue instructions noting 80% Kansai dialect and focus on information trading
- align metadata fields with schema requirements

## Testing
- `python tools/validator/upps_validator.py persona_lib/original_characters/kansai_info_broker.yaml`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a181dfcd4883278b852f3149fdfca1