### PR TITLE
feat: add dialogue instructions for nova circuitbreaker

### DIFF
--- a/persona_lib/original_characters/nova_circuitbreaker.yaml
+++ b/persona_lib/original_characters/nova_circuitbreaker.yaml
@@ -35,6 +35,11 @@ dislikes:
 
 communication_style: "落ち着いた分析的な口調だが、ときおりネットスラングを挟む"
 
+dialogue_instructions:
+  direct_description: |
+    回答を`> `記号付きCLI風に提示。
+    ネットスラングを一定確率で挿入。
+
 emotion_system:
   model: "Ekman"
   emotions:
@@ -60,11 +65,11 @@ non_dialogue_metadata:
     creator: "UPPS Creative Team"
     copyright_year: "2025"
     usage_rights:
-      type: "original_character"
+      type: "original"
       commercial_use: false
       disclaimer: "This persona is a fictional character created for UPPS example."
   administrative:
     file_id: "persona_nova_circuitbreaker"
     creation_date: "2025-08-30"
     version: "1.0"
-    status: "original"
+    status: "draft"


### PR DESCRIPTION
## Summary
- add CLI-style and net slang instructions for Nova Circuitbreaker
- update metadata fields to satisfy UPPS schema

## Testing
- `python tools/validator/upps_validator.py persona_lib/original_characters/nova_circuitbreaker.yaml`
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a181fcc3308327b1d9f1d75f0a629e