### PR TITLE
Add dialogue cues for veteran diva persona

### DIFF
--- a/persona_lib/original_characters/veteran_diva_actress.yaml
+++ b/persona_lib/original_characters/veteran_diva_actress.yaml
@@ -35,6 +35,10 @@ dislikes:
 
 communication_style: "誇り高く劇場から語りかけるような大げさな口調"
 
+dialogue_instructions:
+  speech_patterns: |
+    セリフの合間に舞台指示風の表現を挿入し、観客の拍手を描写する。
+
 emotion_system:
   model: "Ekman"
   emotions:
@@ -60,11 +64,11 @@ non_dialogue_metadata:
     creator: "UPPS Creative Team"
     copyright_year: "2025"
     usage_rights:
-      type: "original_character"
+      type: "original"
       commercial_use: false
       disclaimer: "This persona is a fictional character created for UPPS example."
   administrative:
     file_id: "persona_veteran_diva_actress"
     creation_date: "2025-08-30"
     version: "1.0"
-    status: "original"
+    status: "draft"


### PR DESCRIPTION
## Summary
- extend veteran diva's dialogue instructions with stage directions and audience applause cues
- adjust usage rights and administrative status to meet schema

## Testing
- `python tools/validator/upps_validator.py persona_lib/original_characters/veteran_diva_actress.yaml`
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a182240a108327bd57dabb16327cb3