### PR TITLE
feat: add jealousy trigger for cheating keyword

### DIFF
--- a/persona_lib/lum_urusei_yatsura.yaml
+++ b/persona_lib/lum_urusei_yatsura.yaml
@@ -205,6 +205,16 @@ association_system:
         id: "school_festival_date"
         association_strength: 80
 
+    - id: "ext_cheating_jealousy"
+      trigger:
+        type: "external"
+        category: "topics"
+        items: ["浮気"]
+      response:
+        type: "emotion"
+        id: "jealousy"
+        association_strength: 80
+
     - id: "mem_training_pride"
       trigger:
         type: "memory"


### PR DESCRIPTION
## Summary
- raise jealousy when user mentions cheating

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1822bc7ac83279a6b755077725a04