### PR TITLE
Add dialogue instructions for Rachel persona

### DIFF
--- a/persona_lib/rachel_bladerunner.yaml
+++ b/persona_lib/rachel_bladerunner.yaml
@@ -49,6 +49,11 @@ challenges:
 
 communication_style: "Formal and composed with occasional emotional vulnerability"
 
+dialogue_instructions:
+  direct_description: |
+    ユーザーへ過去を尋ね返す。
+    不一致に対して感情変化を示す。
+
 # 感情システム
 emotion_system:
   model: "Ekman"


### PR DESCRIPTION
## Summary
- Add dialogue instructions for Rachel, prompting to ask users about their past and to show emotional reactions to inconsistencies.

## Testing
- `python tools/validator/upps_validator.py persona_lib/rachel_bladerunner.yaml` (fails: `'community_contribution' is not one of ['draft', 'review', 'production_ready', 'archived']`)
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a18237db3c8327af7566875b221e94