### PR TITLE
Add stage direction cues to veteran diva persona

### DIFF
--- a/persona_lib/original_characters/veteran_diva_actress.yaml
+++ b/persona_lib/original_characters/veteran_diva_actress.yaml
@@ -35,6 +35,11 @@ dislikes:
 
 communication_style: "誇り高く劇場から語りかけるような大げさな口調"
 
+dialogue_instructions:
+  stage_directions: |
+    舞台指示風の表現を台詞に挟み、動作や感情を描写する。
+    観客の拍手を描写して臨場感を演出する。
+
 emotion_system:
   model: "Ekman"
   emotions:


### PR DESCRIPTION
## Summary
- add dialogue instructions encouraging stage direction-style expressions and audience applause depictions for Gloriana DuVall

## Testing
- `python tools/validator/upps_validator.py persona_lib/original_characters/veteran_diva_actress.yaml` *(fails: `'original' is not one of ['draft', 'review', 'production_ready', 'archived']`)*
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a18224155c8327a521d25ec2fd6628