### PR TITLE
feat(editor): integrate medical templates into persona editor

### DIFF
--- a/persona_lib/medical/templates/index.json
+++ b/persona_lib/medical/templates/index.json
@@ -1,0 +1,184 @@
+{
+  "templates": [
+    {
+      "name": "acute_stress_moderate_typical_v1.0",
+      "path": "acute_stress/acute_stress_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "adhd_combined_v1.0",
+      "path": "adhd/adhd_combined_v1.0.yaml"
+    },
+    {
+      "name": "adjustment_mild_depressive_v1.0",
+      "path": "adjustment/adjustment_mild_depressive_v1.0.yaml"
+    },
+    {
+      "name": "alcohol_use_disorder_moderate_typical_v1.0",
+      "path": "alcohol_use/alcohol_use_disorder_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "alzheimer_mild_typical_v1.0",
+      "path": "alzheimer/alzheimer_mild_typical_v1.0.yaml"
+    },
+    {
+      "name": "alzheimer_moderate_anosognosia_v1.0",
+      "path": "alzheimer/alzheimer_moderate_anosognosia_v1.0.yaml"
+    },
+    {
+      "name": "alzheimer_moderate_confabulation_v1.0",
+      "path": "alzheimer/alzheimer_moderate_confabulation_v1.0.yaml"
+    },
+    {
+      "name": "alzheimer_moderate_typical_v1.0",
+      "path": "alzheimer/alzheimer_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "alzheimer_severe_disorientation_v1.0",
+      "path": "alzheimer/alzheimer_severe_disorientation_v1.0.yaml"
+    },
+    {
+      "name": "anorexia_moderate_restricting_v1.0",
+      "path": "anorexia/anorexia_moderate_restricting_v1.0.yaml"
+    },
+    {
+      "name": "antisocial_pd_moderate_typical_v1.0",
+      "path": "antisocial_pd/antisocial_pd_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "anxiety_mild_generalized_v1.0",
+      "path": "anxiety/anxiety_mild_generalized_v1.0.yaml"
+    },
+    {
+      "name": "anxiety_moderate_generalized_v1.0",
+      "path": "anxiety/anxiety_moderate_generalized_v1.0.yaml"
+    },
+    {
+      "name": "autism_typical_v1.0",
+      "path": "autism/autism_typical_v1.0.yaml"
+    },
+    {
+      "name": "avoidant_pd_moderate_typical_v1.0",
+      "path": "avoidant_pd/avoidant_pd_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "binge_eating_moderate_typical_v1.0",
+      "path": "binge_eating/binge_eating_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "bipolar_depressive_moderate_v1.0",
+      "path": "bipolar/bipolar_depressive_moderate_v1.0.yaml"
+    },
+    {
+      "name": "bipolar_manic_moderate_v1.0",
+      "path": "bipolar/bipolar_manic_moderate_v1.0.yaml"
+    },
+    {
+      "name": "bipolar_manic_severe_v1.0",
+      "path": "bipolar/bipolar_manic_severe_v1.0.yaml"
+    },
+    {
+      "name": "body_dysmorphic_moderate_typical_v1.0",
+      "path": "body_dysmorphic/body_dysmorphic_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "borderline_pd_moderate_typical_v1.0",
+      "path": "borderline_pd/borderline_pd_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "bulimia_moderate_purging_v1.0",
+      "path": "bulimia/bulimia_moderate_purging_v1.0.yaml"
+    },
+    {
+      "name": "delusional_disorder_typical_v1.0",
+      "path": "delusional_disorder/delusional_disorder_typical_v1.0.yaml"
+    },
+    {
+      "name": "depersonalization_moderate_typical_v1.0",
+      "path": "depersonalization/depersonalization_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "depression_dysthymic_chronic_v1.0",
+      "path": "depression/depression_dysthymic_chronic_v1.0.yaml"
+    },
+    {
+      "name": "depression_mild_atypical_v1.0",
+      "path": "depression/depression_mild_atypical_v1.0.yaml"
+    },
+    {
+      "name": "depression_mild_typical_v1.0",
+      "path": "depression/depression_mild_typical_v1.0.yaml"
+    },
+    {
+      "name": "depression_moderate_melancholic_v1.0",
+      "path": "depression/depression_moderate_melancholic_v1.0.yaml"
+    },
+    {
+      "name": "dissociative_identity_moderate_typical_v1.0",
+      "path": "dissociative_identity/dissociative_identity_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "gambling_disorder_moderate_typical_v1.0",
+      "path": "gambling/gambling_disorder_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "hoarding_moderate_typical_v1.0",
+      "path": "hoarding/hoarding_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "illness_anxiety_moderate_typical_v1.0",
+      "path": "illness_anxiety/illness_anxiety_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "ocd_moderate_typical_v1.0",
+      "path": "ocd/ocd_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "opioid_use_disorder_moderate_typical_v1.0",
+      "path": "opioid_use/opioid_use_disorder_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "panic_disorder_moderate_v1.0",
+      "path": "panic/panic_disorder_moderate_v1.0.yaml"
+    },
+    {
+      "name": "persistent_depression_v1.0",
+      "path": "persistent_depression/persistent_depression_v1.0.yaml"
+    },
+    {
+      "name": "ptsd_moderate_avoidance_v1.0",
+      "path": "ptsd/ptsd_moderate_avoidance_v1.0.yaml"
+    },
+    {
+      "name": "ptsd_moderate_reexperiencing_v1.0",
+      "path": "ptsd/ptsd_moderate_reexperiencing_v1.0.yaml"
+    },
+    {
+      "name": "schizophrenia_mild_adapted_v1.0",
+      "path": "schizophrenia/schizophrenia_mild_adapted_v1.0.yaml"
+    },
+    {
+      "name": "schizophrenia_mild_negative_v1.0",
+      "path": "schizophrenia/schizophrenia_mild_negative_v1.0.yaml"
+    },
+    {
+      "name": "schizophrenia_moderate_acute_v1.0",
+      "path": "schizophrenia/schizophrenia_moderate_acute_v1.0.yaml"
+    },
+    {
+      "name": "schizophrenia_subtle_positive_v1.0",
+      "path": "schizophrenia/schizophrenia_subtle_positive_v1.0.yaml"
+    },
+    {
+      "name": "social_anxiety_moderate_performance_v1.0",
+      "path": "social_anxiety/social_anxiety_moderate_performance_v1.0.yaml"
+    },
+    {
+      "name": "somatic_symptom_moderate_typical_v1.0",
+      "path": "somatic_symptom/somatic_symptom_moderate_typical_v1.0.yaml"
+    },
+    {
+      "name": "specific_phobia_moderate_animal_v1.0",
+      "path": "specific_phobia/specific_phobia_moderate_animal_v1.0.yaml"
+    }
+  ]
+}

--- a/tools/editor/fileHandler.js
+++ b/tools/editor/fileHandler.js
@@ -28,6 +28,20 @@ export default class FileHandler {
         });
     }
 
+    async loadMedicalTemplate(relativePath) {
+        const basePath = '../../persona_lib/medical/templates/';
+        try {
+            const response = await fetch(basePath + relativePath);
+            const content = await response.text();
+            const templateData = jsyaml.load(content);
+            this.personaData.mergeDiseaseTemplate(templateData);
+            this.uiController.showNotification('医療テンプレートを読み込みました', 'success');
+        } catch (error) {
+            console.error('Template load error:', error);
+            this.uiController.showNotification('テンプレートの読み込みに失敗しました', 'error');
+        }
+    }
+
     saveFile(filename = 'persona.yaml') {
         const yamlContent = this.personaData.toYAML();
         const blob = new Blob([yamlContent], { type: 'text/yaml' });

--- a/tools/editor/index.html
+++ b/tools/editor/index.html
@@ -262,13 +262,27 @@
                     <div class="suggestions">
                         <span class="suggestion" draggable="true" data-snippet="speech_patterns: |\n  " title="キャラクターの語調を指定">話し方・口調</span>
                         <span class="suggestion" draggable="true" data-snippet="behavioral_responses: |\n  " title="想定する振る舞い">行動・反応</span>
-                        <span class="suggestion" draggable="true" data-snippet="special_abilities: |\n  " title="特別なスキルや能力">特殊能力</span>
-                        <span class="suggestion" draggable="true" data-snippet="direct_description: |\n  " title="自然言語による指示">直接記述</span>
-                    </div>
+                    <span class="suggestion" draggable="true" data-snippet="special_abilities: |\n  " title="特別なスキルや能力">特殊能力</span>
+                    <span class="suggestion" draggable="true" data-snippet="direct_description: |\n  " title="自然言語による指示">直接記述</span>
                 </div>
             </div>
+            <div class="card">
+                <h2 class="card-title">医療テンプレート</h2>
+                <div class="form-group">
+                    <label for="medical-template-select">テンプレート選択</label>
+                    <select id="medical-template-select" class="persona-input">
+                        <option value="">選択してください</option>
+                    </select>
+                    <button class="btn btn--primary" onclick="app.handleMergeMedicalTemplate()">適用</button>
+                </div>
+                <div class="form-group">
+                    <label for="disease-prompts">疾患特有プロンプト</label>
+                    <textarea id="disease-prompts" rows="8" class="disease-input"></textarea>
+                </div>
+            </div>
+        </div>
 
-            <!-- Metadata Tab -->
+        <!-- Metadata Tab -->
             <div id="metadata-tab" class="tab-panel">
                 <div class="card">
                     <h2 class="card-title">メタデータ</h2>

--- a/tools/editor/uiController.js
+++ b/tools/editor/uiController.js
@@ -34,6 +34,8 @@ export default class UIController {
                 this.handleDialogueInputChange(e);
             } else if (e.target.matches('.metadata-input')) {
                 this.handleMetadataInputChange(e);
+            } else if (e.target.matches('.disease-input')) {
+                this.handleDiseaseInputChange(e);
             }
         });
 
@@ -138,6 +140,13 @@ export default class UIController {
         }
     }
 
+    handleDiseaseInputChange(e) {
+        const { id, value } = e.target;
+        if (id === 'disease-prompts') {
+            this.personaData.updateDiseasePromptsText(value);
+        }
+    }
+
     updateAllUI() {
         const data = this.personaData.getData();
         this.updatePersonalInfoUI(data);
@@ -146,6 +155,7 @@ export default class UIController {
         this.updateAssociationsUI(data);
         this.updateDialogueInstructionsUI(data);
         this.updateMetadataUI(data);
+        this.updateDiseasePromptsUI(data);
     }
 
     updatePersonalInfoUI(data) {
@@ -215,6 +225,13 @@ export default class UIController {
 
     updateMetadataUI(data) {
         document.getElementById('metadata-text').value = data.non_dialogue_metadata_text || '';
+    }
+
+    updateDiseasePromptsUI(data) {
+        const area = document.getElementById('disease-prompts');
+        if (area) {
+            area.value = data.disease_prompts_text || '';
+        }
     }
 
     renderTrigger(trigger) {


### PR DESCRIPTION
## Summary
- allow FileHandler to fetch YAML medical templates
- add UI for selecting medical templates and disease prompts
- save disease-specific prompts in persona YAML export

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a869a285908327bc50c692bb15cc40