### PR TITLE
Add prompt assembly tab with copy functionality

### DIFF
--- a/tools/editor/index.html
+++ b/tools/editor/index.html
@@ -47,6 +47,9 @@
             <button class="tab-btn" data-tab="preview">
                 📄 プレビュー
             </button>
+            <button class="tab-btn" data-tab="prompt">
+                📋 プロンプト
+            </button>
         </nav>
 
         <!-- Content -->
@@ -292,6 +295,18 @@
                     <div id="yaml-preview" class="preview-container">
 # ここにYAMLプレビューが表示されます
                     </div>
+                </div>
+            </div>
+
+            <!-- Prompt Tab -->
+            <div id="prompt-tab" class="tab-panel">
+                <div class="card">
+                    <h2 class="card-title">組み合わせプロンプト</h2>
+                    <div class="form-group">
+                        <label for="assembled-text">指示 + ペルソナYAML</label>
+                        <textarea id="assembled-text" rows="16" readonly></textarea>
+                    </div>
+                    <button class="btn btn--secondary" id="copy-assembled-btn">Copy All</button>
                 </div>
             </div>
         </main>

--- a/tools/editor/uiController.js
+++ b/tools/editor/uiController.js
@@ -22,6 +22,12 @@ export default class UIController {
                     document.getElementById('metadata-text');
                 this.insertSnippet(textarea, snippet);
             }
+            if (e.target.id === 'copy-assembled-btn') {
+                const text = document.getElementById('assembled-text').value;
+                navigator.clipboard.writeText(text)
+                    .then(() => this.showNotification('プロンプトをコピーしました'))
+                    .catch(() => this.showNotification('コピーに失敗しました', 'error'));
+            }
         });
 
         // データ変更イベント
@@ -86,6 +92,9 @@ export default class UIController {
         if (tabName === 'preview') {
             this.updatePreview();
         }
+        if (tabName === 'prompt') {
+            this.updatePrompt();
+        }
     }
 
     handlePersonalInfoChange(e) {
@@ -146,6 +155,7 @@ export default class UIController {
         this.updateAssociationsUI(data);
         this.updateDialogueInstructionsUI(data);
         this.updateMetadataUI(data);
+        this.updatePrompt();
     }
 
     updatePersonalInfoUI(data) {
@@ -273,6 +283,17 @@ export default class UIController {
         const filled = '■'.repeat(bars);
         const empty = '□'.repeat(10 - bars);
         return `<div class="strength-bar">${filled}${empty} ${strength}</div>`;
+    }
+
+    updatePrompt() {
+        const yamlContent = this.personaData.toYAML();
+        const promptText = `# UPPSペルソナシミュレーション指示（2025.3対応）\n` +
+            `以下のペルソナ設定に従って応答してください。\n\n` +
+            `\u0060\u0060\u0060yaml\n${yamlContent}\n\u0060\u0060\u0060\n`;
+        const area = document.getElementById('assembled-text');
+        if (area) {
+            area.value = promptText;
+        }
     }
 
     updatePreview() {


### PR DESCRIPTION
## Summary
- Add a new "Prompt" tab to the editor that combines instructions with persona YAML output
- Implement clipboard copy button for assembled prompt text
- Extend UI controller to generate and display prompt and integrate new tab into navigation

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a869a56b2083279473691b93358347