### PR TITLE
Add session context editing

### DIFF
--- a/tools/editor/app.js
+++ b/tools/editor/app.js
@@ -61,7 +61,8 @@ class PersonaData {
             },
             dialogue_instructions_text: "",
             non_dialogue_metadata_text: "",
-            disease_prompts_text: ""
+            disease_prompts_text: "",
+            session_context: ""
         };
     }
 
@@ -110,6 +111,11 @@ class PersonaData {
 
     updateDiseasePromptsText(text) {
         this.data.disease_prompts_text = text;
+        this.notifyChange();
+    }
+
+    updateSessionContext(text) {
+        this.data.session_context = text;
         this.notifyChange();
     }
 
@@ -192,6 +198,11 @@ class PersonaData {
         } catch (e) {
             outputData.disease_specific_prompts = this.data.disease_prompts_text || {};
         }
+        try {
+            outputData.session_context = jsyaml.load(this.data.session_context) || {};
+        } catch (e) {
+            outputData.session_context = this.data.session_context || {};
+        }
 
         delete outputData.dialogue_instructions_text;
         delete outputData.non_dialogue_metadata_text;
@@ -218,14 +229,17 @@ class PersonaData {
             const instructions = parsedData.dialogue_instructions;
             const metadata = parsedData.non_dialogue_metadata;
             const disease = parsedData.disease_specific_prompts;
+            const context = parsedData.session_context;
             delete parsedData.dialogue_instructions;
             delete parsedData.non_dialogue_metadata;
             delete parsedData.disease_specific_prompts;
+            delete parsedData.session_context;
 
             this.data = { ...this.getDefaultData(), ...parsedData };
             this.data.dialogue_instructions_text = instructions ? jsyaml.dump(instructions) : '';
             this.data.non_dialogue_metadata_text = metadata ? jsyaml.dump(metadata) : '';
             this.data.disease_prompts_text = disease ? jsyaml.dump(disease) : '';
+            this.data.session_context = context ? jsyaml.dump(context) : '';
             this.notifyChange();
             return true;
         } catch (error) {

--- a/tools/editor/index.html
+++ b/tools/editor/index.html
@@ -44,6 +44,9 @@
             <button class="tab-btn" data-tab="metadata">
                 📑 メタデータ
             </button>
+            <button class="tab-btn" data-tab="context">
+                📚 コンテキスト
+            </button>
             <button class="tab-btn" data-tab="preview">
                 📄 プレビュー
             </button>
@@ -298,6 +301,16 @@
                         <span class="suggestion" draggable="true" data-snippet="copyright_info:\n  " title="権利者やライセンス表記">著作権情報</span>
                         <span class="suggestion" draggable="true" data-snippet="administrative:\n  " title="バージョンや責任者">管理情報</span>
                         <span class="suggestion" draggable="true" data-snippet="usage_terms:\n  - " title="利用規約や禁止事項">使用条件</span>
+                    </div>
+                </div>
+            </div>
+
+            <div id="context-tab" class="tab-panel">
+                <div class="card">
+                    <h2 class="card-title">コンテキスト</h2>
+                    <div class="form-group">
+                        <label for="context-text">コンテキスト</label>
+                        <textarea id="context-text" rows="8" class="context-input"></textarea>
                     </div>
                 </div>
             </div>

--- a/tools/editor/uiController.js
+++ b/tools/editor/uiController.js
@@ -42,6 +42,8 @@ export default class UIController {
                 this.handleMetadataInputChange(e);
             } else if (e.target.matches('.disease-input')) {
                 this.handleDiseaseInputChange(e);
+            } else if (e.target.matches('.context-input')) {
+                this.handleContextInputChange(e);
             }
         });
 
@@ -51,7 +53,7 @@ export default class UIController {
             }
         });
 
-        ['instructions-text', 'metadata-text'].forEach(id => {
+        ['instructions-text', 'metadata-text', 'context-text'].forEach(id => {
             const area = document.getElementById(id);
             area.addEventListener('dragover', e => e.preventDefault());
             area.addEventListener('drop', e => {
@@ -164,6 +166,7 @@ export default class UIController {
         this.updateAssociationsUI(data);
         this.updateDialogueInstructionsUI(data);
         this.updateMetadataUI(data);
+        this.updateContextUI(data);
         this.updatePrompt();
         this.updateDiseasePromptsUI(data);
     }
@@ -241,6 +244,20 @@ export default class UIController {
         const area = document.getElementById('disease-prompts');
         if (area) {
             area.value = data.disease_prompts_text || '';
+        }
+    }
+
+    handleContextInputChange(e) {
+        const { id, value } = e.target;
+        if (id === 'context-text') {
+            this.personaData.updateSessionContext(value);
+        }
+    }
+
+    updateContextUI(data) {
+        const area = document.getElementById('context-text');
+        if (area) {
+            area.value = data.session_context || '';
         }
     }
 


### PR DESCRIPTION
## Summary
- add `session_context` field with serialization in PersonaData
- implement context editing UI and handlers
- expose context tab in editor interface

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a90282871083279661cfc569b5c9b5