### PR TITLE
feat: deep merge disease templates

### DIFF
--- a/tools/editor/app.js
+++ b/tools/editor/app.js
@@ -1,5 +1,6 @@
 import UIController from './uiController.js';
 import FileHandler from './fileHandler.js';
+import deepMerge from '../../utils/deepMerge.js';
 
 class PersonaData {
     constructor() {
@@ -126,7 +127,7 @@ class PersonaData {
         } catch (e) {
             current = {};
         }
-        const merged = { ...current, ...template };
+        const merged = deepMerge(current, template);
         this.data.disease_prompts_text = jsyaml.dump(merged);
         this.notifyChange();
     }

--- a/utils/deepMerge.js
+++ b/utils/deepMerge.js
@@ -1,0 +1,17 @@
+export default function deepMerge(target = {}, source = {}) {
+    const output = { ...target };
+    if (isObject(target) && isObject(source)) {
+        Object.keys(source).forEach(key => {
+            if (isObject(source[key])) {
+                output[key] = key in target ? deepMerge(target[key], source[key]) : source[key];
+            } else {
+                output[key] = source[key];
+            }
+        });
+    }
+    return output;
+}
+
+function isObject(item) {
+    return item && typeof item === 'object' && !Array.isArray(item);
+}

--- a/utils/deepMerge.test.js
+++ b/utils/deepMerge.test.js
@@ -1,0 +1,24 @@
+import deepMerge from './deepMerge.js';
+
+describe('deepMerge', () => {
+    test('merges nested objects', () => {
+        const target = { a: { b: 1, c: { d: 2 } } };
+        const source = { a: { e: 3, c: { f: 4 } }, g: 5 };
+        const result = deepMerge(target, source);
+        expect(result).toEqual({ a: { b: 1, c: { d: 2, f: 4 }, e: 3 }, g: 5 });
+    });
+
+    test('overwrites primitive values', () => {
+        const target = { a: { b: 1 } };
+        const source = { a: 2 };
+        const result = deepMerge(target, source);
+        expect(result).toEqual({ a: 2 });
+    });
+
+    test('merges multiple levels', () => {
+        const target = { a: { b: { c: 1 } } };
+        const source = { a: { b: { d: 2 } } };
+        const result = deepMerge(target, source);
+        expect(result).toEqual({ a: { b: { c: 1, d: 2 } } });
+    });
+});


### PR DESCRIPTION
## Summary
- add reusable `deepMerge` utility for recursive object merging
- update editor to merge disease templates with `deepMerge`
- cover deep merging behavior with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9045e488883278a3852db7d8c1254