### PR TITLE
Reset file input after load to allow reloading same file

### DIFF
--- a/tools/editor/fileHandler.js
+++ b/tools/editor/fileHandler.js
@@ -15,9 +15,11 @@ export default class FileHandler {
                         const content = e.target.result;
                         if (this.personaData.fromYAML(content)) {
                             this.uiController.showNotification('ファイルを正常に読み込みました', 'success');
+                            input.value = '';
                             resolve(true);
                         } else {
                             this.uiController.showNotification('ファイルの読み込みに失敗しました', 'error');
+                            input.value = '';
                             resolve(false);
                         }
                     };


### PR DESCRIPTION
## Summary
- Clear file input value in editor's file handler after load so the same file can be reselected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9086b05c8832790537cf200b24060