### PR TITLE
Add cognitive system editing UI and data handling

### DIFF
--- a/tools/editor/app.js
+++ b/tools/editor/app.js
@@ -37,6 +37,16 @@ class PersonaData {
                     surprise: { baseline: 55, description: "驚き、意外性への反応" }
                 }
             },
+            cognitive_system: {
+                model: "WAIS-IV",
+                abilities: {
+                    verbal_comprehension: { level: 50 },
+                    perceptual_reasoning: { level: 50 },
+                    working_memory: { level: 50 },
+                    processing_speed: { level: 50 }
+                },
+                general_ability: { level: 50 }
+            },
             memory_system: {
                 memories: [
                     {
@@ -90,6 +100,20 @@ class PersonaData {
         Object.keys(emotions).forEach(emotion => {
             if (this.data.emotion_system.emotions[emotion]) {
                 this.data.emotion_system.emotions[emotion].baseline = emotions[emotion];
+            }
+        });
+        this.notifyChange();
+    }
+
+    updateCognitiveSystem(abilities) {
+        Object.keys(abilities).forEach(key => {
+            if (key === 'general_ability') {
+                if (!this.data.cognitive_system.general_ability) {
+                    this.data.cognitive_system.general_ability = { level: 0 };
+                }
+                this.data.cognitive_system.general_ability.level = abilities[key];
+            } else if (this.data.cognitive_system.abilities[key]) {
+                this.data.cognitive_system.abilities[key].level = abilities[key];
             }
         });
         this.notifyChange();
@@ -183,6 +207,21 @@ class PersonaData {
             outputData.personality.traits[trait] = outputData.personality.traits[trait] / 100;
         });
 
+        // 認知能力のレベルを整数に
+        if (outputData.cognitive_system && outputData.cognitive_system.abilities) {
+            Object.keys(outputData.cognitive_system.abilities).forEach(key => {
+                const ability = outputData.cognitive_system.abilities[key];
+                if (ability && ability.level !== undefined) {
+                    ability.level = parseInt(ability.level);
+                }
+            });
+            if (outputData.cognitive_system.general_ability) {
+                outputData.cognitive_system.general_ability.level = parseInt(
+                    outputData.cognitive_system.general_ability.level
+                );
+            }
+        }
+
         // dialogue_instructions と non_dialogue_metadata を YAML オブジェクトに変換
         try {
             outputData.dialogue_instructions = jsyaml.load(this.data.dialogue_instructions_text) || {};
@@ -235,6 +274,22 @@ class PersonaData {
             delete parsedData.non_dialogue_metadata;
             delete parsedData.disease_specific_prompts;
             delete parsedData.session_context;
+
+            // 認知能力レベルを整数化
+            if (parsedData.cognitive_system && parsedData.cognitive_system.abilities) {
+                Object.keys(parsedData.cognitive_system.abilities).forEach(key => {
+                    const ability = parsedData.cognitive_system.abilities[key];
+                    if (ability && ability.level !== undefined) {
+                        ability.level = parseInt(ability.level);
+                    }
+                });
+                if (parsedData.cognitive_system.general_ability &&
+                    parsedData.cognitive_system.general_ability.level !== undefined) {
+                    parsedData.cognitive_system.general_ability.level = parseInt(
+                        parsedData.cognitive_system.general_ability.level
+                    );
+                }
+            }
 
             this.data = { ...this.getDefaultData(), ...parsedData };
             this.data.dialogue_instructions_text = instructions ? jsyaml.dump(instructions) : '';

--- a/tools/editor/index.html
+++ b/tools/editor/index.html
@@ -35,6 +35,9 @@
             <button class="tab-btn" data-tab="emotions">
                 😊 感情システム
             </button>
+            <button class="tab-btn" data-tab="cognitive">
+                🧮 認知能力
+            </button>
             <button class="tab-btn" data-tab="associations">
                 🔗 関連性ネットワーク
             </button>
@@ -209,6 +212,58 @@
                             <span class="slider-value">55</span>
                         </div>
                         <div class="form-help">驚き、意外性への反応</div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Cognitive System Tab -->
+            <div id="cognitive-tab" class="tab-panel">
+                <div class="card">
+                    <h2 class="card-title">認知能力 (WAIS-IV)</h2>
+
+                    <div class="form-group">
+                        <label for="verbal_comprehension-slider">言語理解 (Verbal Comprehension)</label>
+                        <div class="slider-container">
+                            <input type="range" id="verbal_comprehension-slider" class="slider-input" min="0" max="100" value="50">
+                            <span class="slider-value">50</span>
+                        </div>
+                        <div class="form-help">言語理解能力</div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="perceptual_reasoning-slider">知覚推理 (Perceptual Reasoning)</label>
+                        <div class="slider-container">
+                            <input type="range" id="perceptual_reasoning-slider" class="slider-input" min="0" max="100" value="50">
+                            <span class="slider-value">50</span>
+                        </div>
+                        <div class="form-help">視覚的・空間的推理能力</div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="working_memory-slider">ワーキングメモリ (Working Memory)</label>
+                        <div class="slider-container">
+                            <input type="range" id="working_memory-slider" class="slider-input" min="0" max="100" value="50">
+                            <span class="slider-value">50</span>
+                        </div>
+                        <div class="form-help">情報の保持と操作</div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="processing_speed-slider">処理速度 (Processing Speed)</label>
+                        <div class="slider-container">
+                            <input type="range" id="processing_speed-slider" class="slider-input" min="0" max="100" value="50">
+                            <span class="slider-value">50</span>
+                        </div>
+                        <div class="form-help">情報処理の速さ</div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="general_ability-slider">全般的能力 (General Ability)</label>
+                        <div class="slider-container">
+                            <input type="range" id="general_ability-slider" class="slider-input" min="0" max="100" value="50">
+                            <span class="slider-value">50</span>
+                        </div>
+                        <div class="form-help">全体的な認知能力</div>
                     </div>
                 </div>
             </div>

--- a/tools/editor/uiController.js
+++ b/tools/editor/uiController.js
@@ -133,6 +133,9 @@ export default class UIController {
             } else if (['joy', 'sadness', 'anger', 'fear', 'disgust', 'surprise'].includes(traitName)) {
                 valueDisplay.textContent = numValue.toString();
                 this.personaData.updateEmotionSystem({ [traitName]: numValue });
+            } else if (['verbal_comprehension', 'perceptual_reasoning', 'working_memory', 'processing_speed', 'general_ability'].includes(traitName)) {
+                valueDisplay.textContent = numValue.toString();
+                this.personaData.updateCognitiveSystem({ [traitName]: numValue });
             }
         }
     }
@@ -163,6 +166,7 @@ export default class UIController {
         this.updatePersonalInfoUI(data);
         this.updatePersonalityUI(data);
         this.updateEmotionSystemUI(data);
+        this.updateCognitiveSystemUI(data);
         this.updateAssociationsUI(data);
         this.updateDialogueInstructionsUI(data);
         this.updateMetadataUI(data);
@@ -197,6 +201,25 @@ export default class UIController {
             slider.value = emotions[emotion].baseline;
             valueDisplay.textContent = emotions[emotion].baseline.toString();
         });
+    }
+
+    updateCognitiveSystemUI(data) {
+        const abilities = data.cognitive_system.abilities;
+        Object.keys(abilities).forEach(ability => {
+            const slider = document.getElementById(`${ability}-slider`);
+            if (slider) {
+                const valueDisplay = slider.parentNode.querySelector('.slider-value');
+                slider.value = abilities[ability].level;
+                valueDisplay.textContent = abilities[ability].level.toString();
+            }
+        });
+        const general = data.cognitive_system.general_ability;
+        const gSlider = document.getElementById('general_ability-slider');
+        if (gSlider) {
+            const valueDisplay = gSlider.parentNode.querySelector('.slider-value');
+            gSlider.value = general.level;
+            valueDisplay.textContent = general.level.toString();
+        }
     }
 
     updateAssociationsUI(data) {


### PR DESCRIPTION
## Summary
- add WAIS-IV cognitive system defaults to persona data
- support cognitive ability updates with YAML import/export
- provide UI and controller logic for editing cognitive abilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a932e2ac408327add673a4837be64c