### PR TITLE
Add current emotion state editing and serialization

### DIFF
--- a/tools/editor/app.js
+++ b/tools/editor/app.js
@@ -37,6 +37,14 @@ class PersonaData {
                     surprise: { baseline: 55, description: "驚き、意外性への反応" }
                 }
             },
+            current_emotion_state: {
+                joy: 50,
+                sadness: 30,
+                anger: 25,
+                fear: 40,
+                disgust: 20,
+                surprise: 55
+            },
             cognitive_system: {
                 model: "WAIS-IV",
                 abilities: {
@@ -101,6 +109,13 @@ class PersonaData {
             if (this.data.emotion_system.emotions[emotion]) {
                 this.data.emotion_system.emotions[emotion].baseline = emotions[emotion];
             }
+        });
+        this.notifyChange();
+    }
+
+    updateCurrentEmotionState(states) {
+        Object.keys(states).forEach(emotion => {
+            this.data.current_emotion_state[emotion] = states[emotion];
         });
         this.notifyChange();
     }
@@ -222,6 +237,13 @@ class PersonaData {
             }
         }
 
+        // 現在の感情状態を整数に
+        if (outputData.current_emotion_state) {
+            Object.keys(outputData.current_emotion_state).forEach(key => {
+                outputData.current_emotion_state[key] = parseInt(outputData.current_emotion_state[key]);
+            });
+        }
+
         // dialogue_instructions と non_dialogue_metadata を YAML オブジェクトに変換
         try {
             outputData.dialogue_instructions = jsyaml.load(this.data.dialogue_instructions_text) || {};
@@ -289,6 +311,13 @@ class PersonaData {
                         parsedData.cognitive_system.general_ability.level
                     );
                 }
+            }
+
+            // 現在の感情状態を整数化
+            if (parsedData.current_emotion_state) {
+                Object.keys(parsedData.current_emotion_state).forEach(key => {
+                    parsedData.current_emotion_state[key] = parseInt(parsedData.current_emotion_state[key]);
+                });
             }
 
             this.data = { ...this.getDefaultData(), ...parsedData };

--- a/tools/editor/index.html
+++ b/tools/editor/index.html
@@ -216,6 +216,58 @@
                 </div>
             </div>
 
+            <div class="card">
+                <h2 class="card-title">現在の感情状態</h2>
+
+                <div class="form-group">
+                    <label for="current_joy-slider">喜び (Joy)</label>
+                    <div class="slider-container">
+                        <input type="range" id="current_joy-slider" class="slider-input" min="0" max="100" value="50">
+                        <span class="slider-value">50</span>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="current_sadness-slider">悲しみ (Sadness)</label>
+                    <div class="slider-container">
+                        <input type="range" id="current_sadness-slider" class="slider-input" min="0" max="100" value="30">
+                        <span class="slider-value">30</span>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="current_anger-slider">怒り (Anger)</label>
+                    <div class="slider-container">
+                        <input type="range" id="current_anger-slider" class="slider-input" min="0" max="100" value="25">
+                        <span class="slider-value">25</span>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="current_fear-slider">恐れ (Fear)</label>
+                    <div class="slider-container">
+                        <input type="range" id="current_fear-slider" class="slider-input" min="0" max="100" value="40">
+                        <span class="slider-value">40</span>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="current_disgust-slider">嫌悪 (Disgust)</label>
+                    <div class="slider-container">
+                        <input type="range" id="current_disgust-slider" class="slider-input" min="0" max="100" value="20">
+                        <span class="slider-value">20</span>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="current_surprise-slider">驚き (Surprise)</label>
+                    <div class="slider-container">
+                        <input type="range" id="current_surprise-slider" class="slider-input" min="0" max="100" value="55">
+                        <span class="slider-value">55</span>
+                    </div>
+                </div>
+            </div>
+
             <!-- Cognitive System Tab -->
             <div id="cognitive-tab" class="tab-panel">
                 <div class="card">

--- a/tools/editor/uiController.js
+++ b/tools/editor/uiController.js
@@ -123,11 +123,15 @@ export default class UIController {
 
         // スライダー値表示を更新
         const valueDisplay = e.target.parentNode.querySelector('.slider-value');
-        
+
         if (id.includes('-slider')) {
             const traitName = id.replace('-slider', '');
-            
-            if (['openness', 'conscientiousness', 'extraversion', 'agreeableness', 'neuroticism'].includes(traitName)) {
+
+            if (traitName.startsWith('current_')) {
+                const emotion = traitName.replace('current_', '');
+                valueDisplay.textContent = numValue.toString();
+                this.personaData.updateCurrentEmotionState({ [emotion]: numValue });
+            } else if (['openness', 'conscientiousness', 'extraversion', 'agreeableness', 'neuroticism'].includes(traitName)) {
                 valueDisplay.textContent = numValue + '%';
                 this.personaData.updatePersonality({ [traitName]: numValue });
             } else if (['joy', 'sadness', 'anger', 'fear', 'disgust', 'surprise'].includes(traitName)) {
@@ -195,11 +199,22 @@ export default class UIController {
 
     updateEmotionSystemUI(data) {
         const emotions = data.emotion_system.emotions;
+        const current = data.current_emotion_state || {};
         Object.keys(emotions).forEach(emotion => {
             const slider = document.getElementById(`${emotion}-slider`);
-            const valueDisplay = slider.parentNode.querySelector('.slider-value');
-            slider.value = emotions[emotion].baseline;
-            valueDisplay.textContent = emotions[emotion].baseline.toString();
+            if (slider) {
+                const valueDisplay = slider.parentNode.querySelector('.slider-value');
+                slider.value = emotions[emotion].baseline;
+                valueDisplay.textContent = emotions[emotion].baseline.toString();
+            }
+
+            const currentSlider = document.getElementById(`current_${emotion}-slider`);
+            if (currentSlider) {
+                const currentValueDisplay = currentSlider.parentNode.querySelector('.slider-value');
+                const value = current[emotion] !== undefined ? current[emotion] : emotions[emotion].baseline;
+                currentSlider.value = value;
+                currentValueDisplay.textContent = value.toString();
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- track current emotion state in PersonaData defaults and YAML import/export
- provide sliders in the editor for editing current emotion state
- bind UI controls to PersonaData with update logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9354fac4c832782214ca8ef658713