### PR TITLE
Use template-based prompt assembly

### DIFF
--- a/tools/editor/index.html
+++ b/tools/editor/index.html
@@ -54,7 +54,7 @@
                 📄 プレビュー
             </button>
             <button class="tab-btn" data-tab="prompt">
-                📋 プロンプト
+                📋 会話開始用プロンプト
             </button>
         </nav>
 
@@ -435,12 +435,12 @@
             <!-- Prompt Tab -->
             <div id="prompt-tab" class="tab-panel">
                 <div class="card">
-                    <h2 class="card-title">組み合わせプロンプト</h2>
+                    <h2 class="card-title">会話開始用プロンプト</h2>
                     <div class="form-group">
-                        <label for="assembled-text">指示 + ペルソナYAML</label>
+                        <label for="assembled-text">以下をコピーして会話を開始</label>
                         <textarea id="assembled-text" rows="16" readonly></textarea>
                     </div>
-                    <button class="btn btn--secondary" id="copy-assembled-btn">Copy All</button>
+                    <button class="btn btn--primary" id="copy-assembled-btn">プロンプトをコピー</button>
                 </div>
             </div>
         </main>


### PR DESCRIPTION
## Summary
- Build conversation prompts from `basic_template.md` and append dialogue instructions, disease-specific prompts, and session context
- Emphasize copy-friendly prompt tab labeled "会話開始用プロンプト" with primary copy button
- Auto-select generated prompt when clicked for easier copying

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9886fe7e483279a962139f2eab3e0