### PR TITLE
feat: validate persona data before saving

### DIFF
--- a/tools/editor/fileHandler.js
+++ b/tools/editor/fileHandler.js
@@ -1,3 +1,5 @@
+import { validatePersona } from './validator.js';
+
 export default class FileHandler {
     constructor(personaData, uiController) {
         this.personaData = personaData;
@@ -49,9 +51,23 @@ export default class FileHandler {
 
     saveFile(filename = 'persona.yaml') {
         const yamlContent = this.personaData.toYAML();
+        let profile;
+        try {
+            profile = jsyaml.load(yamlContent);
+        } catch (e) {
+            this.uiController.showNotification('YAMLの生成に失敗しました', 'error');
+            return;
+        }
+
+        const result = validatePersona(profile);
+        if (!result.valid) {
+            this.uiController.showNotification(result.errors.join('\n'), 'error');
+            return;
+        }
+
         const blob = new Blob([yamlContent], { type: 'text/yaml' });
         const url = window.URL.createObjectURL(blob);
-        
+
         const a = document.createElement('a');
         a.href = url;
         a.download = filename;
@@ -59,7 +75,7 @@ export default class FileHandler {
         a.click();
         document.body.removeChild(a);
         window.URL.revokeObjectURL(url);
-        
+
         this.uiController.showNotification('ファイルを保存しました', 'success');
     }
 }

--- a/tools/editor/validator.js
+++ b/tools/editor/validator.js
@@ -1,0 +1,73 @@
+export function validatePersona(profile) {
+    const errors = [];
+
+    // collect emotion IDs
+    const emotionIds = new Set();
+    if (profile.emotion_system) {
+        if (profile.emotion_system.emotions) {
+            Object.keys(profile.emotion_system.emotions).forEach(id => emotionIds.add(id));
+        }
+        if (profile.emotion_system.additional_emotions) {
+            Object.keys(profile.emotion_system.additional_emotions).forEach(id => emotionIds.add(id));
+        }
+        if (profile.emotion_system.compound_emotions) {
+            Object.keys(profile.emotion_system.compound_emotions).forEach(id => emotionIds.add(id));
+        }
+    }
+
+    // collect memory IDs
+    const memoryIds = new Set();
+    if (profile.memory_system && Array.isArray(profile.memory_system.memories)) {
+        profile.memory_system.memories.forEach(m => {
+            if (m && m.id) {
+                memoryIds.add(m.id);
+            }
+        });
+    }
+
+    // association reference validation
+    if (profile.association_system && Array.isArray(profile.association_system.associations)) {
+        profile.association_system.associations.forEach((assoc, i) => {
+            const index = i + 1;
+            const trigger = assoc.trigger || {};
+            if (trigger.type === 'memory' && trigger.id && !memoryIds.has(trigger.id)) {
+                errors.push(`関連性 #${index}: トリガーが存在しない記憶ID '${trigger.id}' を参照しています`);
+            }
+            if (trigger.type === 'emotion' && trigger.id && !emotionIds.has(trigger.id)) {
+                errors.push(`関連性 #${index}: トリガーが存在しない感情ID '${trigger.id}' を参照しています`);
+            }
+            if (trigger.operator && Array.isArray(trigger.conditions)) {
+                trigger.conditions.forEach((condition, j) => {
+                    const cIndex = j + 1;
+                    if (condition.type === 'memory' && condition.id && !memoryIds.has(condition.id)) {
+                        errors.push(`関連性 #${index}, 条件 #${cIndex}: 条件が存在しない記憶ID '${condition.id}' を参照しています`);
+                    }
+                    if (condition.type === 'emotion' && condition.id && !emotionIds.has(condition.id)) {
+                        errors.push(`関連性 #${index}, 条件 #${cIndex}: 条件が存在しない感情ID '${condition.id}' を参照しています`);
+                    }
+                });
+            }
+            const response = assoc.response || {};
+            if (response.type === 'memory' && response.id && !memoryIds.has(response.id)) {
+                errors.push(`関連性 #${index}: レスポンスが存在しない記憶ID '${response.id}' を参照しています`);
+            }
+            if (response.type === 'emotion' && response.id && !emotionIds.has(response.id)) {
+                errors.push(`関連性 #${index}: レスポンスが存在しない感情ID '${response.id}' を参照しています`);
+            }
+        });
+    }
+
+    // current_emotion_state consistency
+    if (profile.current_emotion_state) {
+        Object.keys(profile.current_emotion_state).forEach(id => {
+            if (!emotionIds.has(id)) {
+                errors.push(`current_emotion_stateの感情 '${id}' は感情システムで定義されていません`);
+            }
+        });
+    }
+
+    return {
+        valid: errors.length === 0,
+        errors
+    };
+}


### PR DESCRIPTION
## Summary
- add browser-side validator for UPPS persona data
- block saving when validation errors exist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a989a587888327925a8d45764dea84