### PR TITLE
Add js-yaml dependency and import for editor YAML features

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   },
   "devDependencies": {
     "jest": "^29.6.0"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0"
   }
 }

--- a/tools/editor/app.js
+++ b/tools/editor/app.js
@@ -1,3 +1,4 @@
+import jsyaml from 'js-yaml';
 import UIController from './uiController.js';
 import FileHandler from './fileHandler.js';
 import deepMerge from '../../utils/deepMerge.js';

--- a/tools/editor/fileHandler.js
+++ b/tools/editor/fileHandler.js
@@ -1,3 +1,4 @@
+import jsyaml from 'js-yaml';
 import { validatePersona } from './validator.js';
 
 export default class FileHandler {


### PR DESCRIPTION
## Summary
- add `js-yaml` package dependency
- import `jsyaml` in editor modules for YAML handling

## Testing
- `npm test`
- Attempted to launch editor via jsdom (DOM elements missing)

------
https://chatgpt.com/codex/tasks/task_e_68a98d48478883279aa2574232ea5e5c