### PR TITLE
Fix persona editor file load and event handling

### DIFF
--- a/tools/editor/app.js
+++ b/tools/editor/app.js
@@ -605,6 +605,14 @@ class App {
         if (e.target.id === 'template-modal') {
             this.closeTemplateModal();
         }
+        if (e.target.classList.contains('edit-association')) {
+            const id = parseInt(e.target.dataset.id, 10);
+            this.editAssociation(id);
+        }
+        if (e.target.classList.contains('delete-association')) {
+            const id = parseInt(e.target.dataset.id, 10);
+            this.deleteAssociation(id);
+        }
     }
 
     handleShortcutKeys(e) {

--- a/tools/editor/fileHandler.js
+++ b/tools/editor/fileHandler.js
@@ -10,8 +10,15 @@ export default class FileHandler {
     async loadFile() {
         return new Promise((resolve) => {
             const input = document.getElementById('file-input');
-            input.onchange = (e) => {
+
+            const cleanup = () => {
+                input.removeEventListener('change', onChange);
+                input.removeEventListener('focusout', onFocusOut);
+            };
+
+            const onChange = (e) => {
                 const file = e.target.files[0];
+                cleanup();
                 if (file) {
                     const reader = new FileReader();
                     reader.onload = (e) => {
@@ -27,8 +34,25 @@ export default class FileHandler {
                         }
                     };
                     reader.readAsText(file);
+                } else {
+                    input.value = '';
+                    this.uiController.showNotification('ファイルの選択がキャンセルされました', 'error');
+                    resolve(false);
                 }
             };
+
+            const onFocusOut = () => {
+                // ユーザーがダイアログをキャンセルした場合にも Promise を解決する
+                if (!input.files || input.files.length === 0) {
+                    cleanup();
+                    input.value = '';
+                    this.uiController.showNotification('ファイルの選択がキャンセルされました', 'error');
+                    resolve(false);
+                }
+            };
+
+            input.addEventListener('change', onChange, { once: true });
+            input.addEventListener('focusout', onFocusOut, { once: true });
             input.click();
         });
     }

--- a/tools/editor/index.html
+++ b/tools/editor/index.html
@@ -573,8 +573,6 @@
         </div>
     </div>
 
-    <!-- js-yaml CDN -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
     <script type="module" src="./app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Ensure file loading resolves even if user cancels the file dialog
- Guard DOM access and modularize association table actions to avoid global handlers
- Remove js-yaml CDN reference in editor HTML

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a98bfee250832785934ac7da7e65e6