### PR TITLE
Use pathlib for schema resolution and support overrides

### DIFF
--- a/tools/validator/upps_validator.py
+++ b/tools/validator/upps_validator.py
@@ -34,7 +34,10 @@ def main() -> None:
         help="Run only reference integrity validation",
     )
     parser.add_argument("--all", action="store_true", help="Run all validations")
-    parser.add_argument("--schema-path", help="Path to UPPS schema file")
+    parser.add_argument(
+        "--schema-path",
+        help="Path to UPPS schema file. Can also be set via UPPS_SCHEMA_PATH.",
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- resolve schema paths relative to `validator_utils` using `pathlib`
- allow schema location override via `schema_path` arg or `UPPS_SCHEMA_PATH`
- document env var override in validator CLI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bad8a8474883279944c5ce575cd346