### PR TITLE
Add Big Five traits and update status for Lum persona

### DIFF
--- a/persona_lib/lum_urusei_yatsura.yaml
+++ b/persona_lib/lum_urusei_yatsura.yaml
@@ -8,6 +8,15 @@ background: |
   遠い宇宙の鬼族出身の少女。地球侵略時に諸星あたると鬼ごっこで戦い、
   あたるの言葉を結婚の約束と勘違いして地球に居着く。
 
+personality:
+  model: "BigFive"
+  traits:
+    openness: 0.8
+    conscientiousness: 0.4
+    extraversion: 0.9
+    agreeableness: 0.6
+    neuroticism: 0.3
+
 # 対話実行指示
 dialogue_instructions:
   speech_patterns: |
@@ -266,4 +275,4 @@ non_dialogue_metadata:
     creation_date: "2025-01-15"
     intended_use: "educational_entertainment"
     version: "1.0"
-    status: "community_contribution"
+    status: "draft"


### PR DESCRIPTION
## Summary
- add Big Five personality traits to Lum profile
- mark Lum persona status as draft

## Testing
- `python tools/validator/upps_validator.py persona_lib/lum_urusei_yatsura.yaml --all` *(fails: 'association_strength' is a required property; profile version mismatch; missing dialogue and clinical fields)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcc3b26d88327b6f920595902c5ec