### PR TITLE
Update medical personas to 2025.3 version

### DIFF
--- a/persona_lib/medical/examples/acute_stress_MT.yaml
+++ b/persona_lib/medical/examples/acute_stress_MT.yaml
@@ -110,7 +110,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_acute_stress_MT"
     creation_date: "2025-08-01"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/adhd_JM.yaml
+++ b/persona_lib/medical/examples/adhd_JM.yaml
@@ -114,7 +114,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_adhd_JM_designer"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/adjustment_HS.yaml
+++ b/persona_lib/medical/examples/adjustment_HS.yaml
@@ -110,7 +110,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_adjustment_HS"
     creation_date: "2025-08-01"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/alcohol_use_HS.yaml
+++ b/persona_lib/medical/examples/alcohol_use_HS.yaml
@@ -111,7 +111,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_alcohol_use_HS_sales"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/alzheimer_TH.yaml
+++ b/persona_lib/medical/examples/alzheimer_TH.yaml
@@ -234,7 +234,7 @@ non_dialogue_metadata:
     file_id: "persona_alzheimer_TH_teacher"
     creation_date: "2025-01-15"
     last_updated: "2025-01-20"
-    version: "1.2"
+    version: "2025.3 v1.0.0"
     status: "production_ready"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/anorexia_MT.yaml
+++ b/persona_lib/medical/examples/anorexia_MT.yaml
@@ -121,7 +121,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_anorexia_MT_student"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/antisocial_pd_DT.yaml
+++ b/persona_lib/medical/examples/antisocial_pd_DT.yaml
@@ -105,7 +105,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_antisocial_pd_DT"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/anxiety_SY.yaml
+++ b/persona_lib/medical/examples/anxiety_SY.yaml
@@ -133,7 +133,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_anxiety_SY_student"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/autism_HS.yaml
+++ b/persona_lib/medical/examples/autism_HS.yaml
@@ -114,7 +114,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_autism_HS_student"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/avoidant_pd_HM.yaml
+++ b/persona_lib/medical/examples/avoidant_pd_HM.yaml
@@ -105,7 +105,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_avoidant_pd_HM"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/binge_eating_HK.yaml
+++ b/persona_lib/medical/examples/binge_eating_HK.yaml
@@ -121,7 +121,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_binge_eating_HK_worker"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/bipolar_MO.yaml
+++ b/persona_lib/medical/examples/bipolar_MO.yaml
@@ -144,7 +144,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_bipolar_MO_entrepreneur"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/bipolar_NA.yaml
+++ b/persona_lib/medical/examples/bipolar_NA.yaml
@@ -144,7 +144,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_bipolar_NA_designer"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/body_dysmorphic_MS.yaml
+++ b/persona_lib/medical/examples/body_dysmorphic_MS.yaml
@@ -130,7 +130,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_body_dysmorphic_MS"
     creation_date: "2025-08-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/borderline_pd_JK.yaml
+++ b/persona_lib/medical/examples/borderline_pd_JK.yaml
@@ -108,7 +108,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_borderline_pd_JK"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/bulimia_SN.yaml
+++ b/persona_lib/medical/examples/bulimia_SN.yaml
@@ -121,7 +121,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_bulimia_SN_worker"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/delusional_disorder_AH.yaml
+++ b/persona_lib/medical/examples/delusional_disorder_AH.yaml
@@ -109,7 +109,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_delusional_disorder_AH"
     creation_date: "2025-08-01"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/depersonalization_BQ.yaml
+++ b/persona_lib/medical/examples/depersonalization_BQ.yaml
@@ -121,7 +121,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_depersonalization_BQ_student"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/depression_YT.yaml
+++ b/persona_lib/medical/examples/depression_YT.yaml
@@ -144,7 +144,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_depression_YT_sales"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/dissociative_identity_AZ.yaml
+++ b/persona_lib/medical/examples/dissociative_identity_AZ.yaml
@@ -122,7 +122,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_dissociative_identity_AZ_designer"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/gambling_NM.yaml
+++ b/persona_lib/medical/examples/gambling_NM.yaml
@@ -111,7 +111,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_gambling_NM_engineer"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/hoarding_AT.yaml
+++ b/persona_lib/medical/examples/hoarding_AT.yaml
@@ -130,7 +130,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_hoarding_AT"
     creation_date: "2025-08-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/illness_anxiety_HK.yaml
+++ b/persona_lib/medical/examples/illness_anxiety_HK.yaml
@@ -78,7 +78,7 @@ memory_system:
 
     - id: "doctor_visit"
       type: "episodic"
-      content: "何度目かの受診で医師から"健康です"と言われた"
+      content: "何度目かの受診で医師から\"健康です\"と言われた"
       period: "3 months ago"
       emotional_valence: "positive"
       associated_emotions: ["relief"]
@@ -127,7 +127,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_illness_anxiety_HK"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/ocd_YK.yaml
+++ b/persona_lib/medical/examples/ocd_YK.yaml
@@ -114,7 +114,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_ocd_YK_office_worker"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/opioid_use_MT.yaml
+++ b/persona_lib/medical/examples/opioid_use_MT.yaml
@@ -111,7 +111,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_opioid_use_MT_office"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/panic_TK.yaml
+++ b/persona_lib/medical/examples/panic_TK.yaml
@@ -141,7 +141,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_panic_TK_driver"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/persistent_depression_MA.yaml
+++ b/persona_lib/medical/examples/persistent_depression_MA.yaml
@@ -116,7 +116,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_persistent_depression_MA"
     creation_date: "2025-08-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/ptsd_KW.yaml
+++ b/persona_lib/medical/examples/ptsd_KW.yaml
@@ -144,7 +144,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_ptsd_KW_firefighter"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/schizophrenia_MT.yaml
+++ b/persona_lib/medical/examples/schizophrenia_MT.yaml
@@ -109,7 +109,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_schizophrenia_MT"
     creation_date: "2025-08-01"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/social_anxiety_NH.yaml
+++ b/persona_lib/medical/examples/social_anxiety_NH.yaml
@@ -113,3 +113,31 @@ current_emotion_state:
   anxiety: 70
   embarrassment: 65
   joy: 45
+
+non_dialogue_metadata:
+  clinical_data:
+    primary_diagnosis:
+      icd_11: "6B05"
+      dsm_5_tr: "300.23"
+      name_jp: "社交不安症"
+      severity: "moderate"
+    educational_objectives:
+      - "社交不安症の理解"
+      - "公的場面での不安管理"
+  validation:
+    approval_status: "pending"
+  administrative:
+    file_id: "persona_social_anxiety_NH_sales"
+    creation_date: "2025-07-30"
+    version: "2025.3 v1.0.0"
+    status: "draft"
+    creator: "UPPS Consortium Medical Team"
+    intended_use: "medical_education"
+    template_dependencies:
+      - "social_anxiety_moderate_performance_v1.0"
+    usage_terms:
+      - "医療・教育目的のみ使用可能"
+      - "商用利用禁止"
+      - "患者の尊厳を保った使用"
+      - "テンプレート改変時は再検証必要"
+      - "架空患者であることを明示"

--- a/persona_lib/medical/examples/somatic_symptom_MS.yaml
+++ b/persona_lib/medical/examples/somatic_symptom_MS.yaml
@@ -78,7 +78,7 @@ memory_system:
 
     - id: "doctor_reassurance"
       type: "episodic"
-      content: "信頼できる医師から"大きな病気ではない"と説明された"
+      content: "信頼できる医師から\"大きな病気ではない\"と説明された"
       period: "6 months ago"
       emotional_valence: "positive"
       associated_emotions: ["relief"]
@@ -127,7 +127,7 @@ non_dialogue_metadata:
   administrative:
     file_id: "persona_somatic_symptom_MS"
     creation_date: "2025-07-30"
-    version: "1.0"
+    version: "2025.3 v1.0.0"
     status: "draft"
     creator: "UPPS Consortium Medical Team"
     intended_use: "medical_education"

--- a/persona_lib/medical/examples/specific_phobia_AK.yaml
+++ b/persona_lib/medical/examples/specific_phobia_AK.yaml
@@ -113,3 +113,31 @@ current_emotion_state:
   fear: 75
   anxiety: 65
   joy: 50
+
+non_dialogue_metadata:
+  clinical_data:
+    primary_diagnosis:
+      icd_11: "6B02"
+      dsm_5_tr: "300.29"
+      name_jp: "特定恐怖症（動物）"
+      severity: "moderate"
+    educational_objectives:
+      - "特定恐怖症の理解"
+      - "暴露療法の支援"
+  validation:
+    approval_status: "pending"
+  administrative:
+    file_id: "persona_specific_phobia_AK_writer"
+    creation_date: "2025-07-30"
+    version: "2025.3 v1.0.0"
+    status: "draft"
+    creator: "UPPS Consortium Medical Team"
+    intended_use: "medical_education"
+    template_dependencies:
+      - "specific_phobia_moderate_animal_v1.0"
+    usage_terms:
+      - "医療・教育目的のみ使用可能"
+      - "商用利用禁止"
+      - "患者の尊厳を保った使用"
+      - "テンプレート改変時は再検証必要"
+      - "架空患者であることを明示"


### PR DESCRIPTION
## Summary
- Bump `non_dialogue_metadata.administrative.version` to `2025.3 v1.0.0` across all medical persona examples
- Add missing `non_dialogue_metadata` blocks for social anxiety and specific phobia examples
- Fix YAML quoting errors in illness anxiety and somatic symptom profiles

## Testing
- `for f in persona_lib/medical/examples/*.yaml; do echo "Validating $f"; python tools/validator/upps_validator.py "$f" --all | rg 'バージョン検証'; done`


------
https://chatgpt.com/codex/tasks/task_e_68bbd099337c83278034c045e120c518