### PR TITLE
Normalize cognitive ability scores

### DIFF
--- a/persona_lib/lum_urusei_yatsura.yaml
+++ b/persona_lib/lum_urusei_yatsura.yaml
@@ -139,6 +139,26 @@ memory_system:
       emotional_valence: "positive"
       associated_emotions: ["love", "joy", "surprise"]
 
+# 認知能力システム
+cognitive_system:
+  model: "WAIS-IV"
+  abilities:
+    verbal_comprehension:
+      level: 60
+      description: "地球語も日常会話は得意だが、学術的な表現は苦手"
+    perceptual_reasoning:
+      level: 75
+      description: "直感的なパターン認識と空間把握に優れる"
+    working_memory:
+      level: 55
+      description: "興味のない事には注意が散漫"
+    processing_speed:
+      level: 80
+      description: "反応が速く、電撃も即座に放てる"
+  general_ability:
+    level: 68
+    description: "身体能力と反射神経は優秀だが、学習面は平均的"
+
 # 動的変容（感情と能力の連動）
 association_system:
   associations:
@@ -157,6 +177,7 @@ association_system:
         id: "electric_shock"
         intensity_factor: "emotion_level"
         description: "感情高ぶりによる電撃発動"
+        association_strength: 90
 
     - id: "mem_flirt_jealousy"
       trigger:

--- a/persona_lib/medical/examples/autism_HS.yaml
+++ b/persona_lib/medical/examples/autism_HS.yaml
@@ -75,16 +75,16 @@ cognitive_system:
   model: "WAIS-IV"
   abilities:
     verbal_comprehension:
-      level: 105
+      level: 60
       description: "語彙は豊富だが比喩理解は苦手"
     perceptual_reasoning:
-      level: 110
+      level: 75
       description: "視覚的なパターン認識が得意"
     working_memory:
-      level: 100
+      level: 60
       description: "興味のある内容なら集中できる"
     processing_speed:
-      level: 95
+      level: 55
       description: "変化への適応に時間がかかる"
 
 dialogue_instructions:

--- a/persona_lib/medical/examples/schizophrenia_MT.yaml
+++ b/persona_lib/medical/examples/schizophrenia_MT.yaml
@@ -71,16 +71,16 @@ cognitive_system:
   model: "WAIS-IV"
   abilities:
     verbal_comprehension:
-      level: 80
+      level: 45
       description: "やや低下"
-    working_memory:
-      level: 75
-      description: "注意が散漫"
     perceptual_reasoning:
-      level: 90
+      level: 60
       description: "平均的"
+    working_memory:
+      level: 45
+      description: "注意が散漫"
     processing_speed:
-      level: 70
+      level: 40
       description: "反応が遅い"
 
 dialogue_instructions:


### PR DESCRIPTION
## Summary
- add WAIS-IV cognitive system for Lum with balanced ability and general scores
- normalize WAIS-based levels in autism and schizophrenia medical personas

## Testing
- `python tools/validator/upps_validator.py persona_lib/lum_urusei_yatsura.yaml --all`
- `python tools/validator/upps_validator.py persona_lib/medical/examples/autism_HS.yaml --all`
- `python tools/validator/upps_validator.py persona_lib/medical/examples/schizophrenia_MT.yaml --all`


------
https://chatgpt.com/codex/tasks/task_e_68bbd3f15f5c83279007a4caf681b6aa