### PR TITLE
Align psychiatric personas with UPPS standard

### DIFF
--- a/persona_lib/medical/examples/acute_stress_MT.yaml
+++ b/persona_lib/medical/examples/acute_stress_MT.yaml
@@ -79,9 +79,18 @@ cognitive_system:
     verbal_comprehension:
       level: 80
       description: "平均的"
+    perceptual_reasoning:
+      level: 78
+      description: "状況判断は素早い"
     working_memory:
       level: 75
       description: "事故後集中しにくい"
+    processing_speed:
+      level: 72
+      description: "緊張時にやや低下"
+  general_ability:
+    level: 76
+    description: "全体的に平均的だがストレスで能力が揺らぐ"
 
 dialogue_instructions:
   template_ref: "acute_stress_moderate_typical_v1.0"

--- a/persona_lib/medical/examples/adjustment_HS.yaml
+++ b/persona_lib/medical/examples/adjustment_HS.yaml
@@ -79,9 +79,18 @@ cognitive_system:
     verbal_comprehension:
       level: 85
       description: "コミュニケーション能力は十分"
+    perceptual_reasoning:
+      level: 82
+      description: "状況変化への理解は良好"
     working_memory:
       level: 80
       description: "仕事の変化により集中力が低下"
+    processing_speed:
+      level: 78
+      description: "ストレスでやや遅い"
+  general_ability:
+    level: 80
+    description: "全般的な認知機能は平均的"
 
 dialogue_instructions:
   template_ref: "adjustment_mild_depressive_v1.0"

--- a/persona_lib/medical/examples/alcohol_use_HS.yaml
+++ b/persona_lib/medical/examples/alcohol_use_HS.yaml
@@ -77,12 +77,18 @@ cognitive_system:
     verbal_comprehension:
       level: 85
       description: "会話は得意"
+    perceptual_reasoning:
+      level: 80
+      description: "状況判断は平均的"
     working_memory:
       level: 70
       description: "飲酒翌日は集中が落ちる"
     processing_speed:
       level: 80
       description: "平均的"
+  general_ability:
+    level: 78
+    description: "飲酒の影響を除けば認知機能は安定"
 
 dialogue_instructions:
   template_ref: "alcohol_use_disorder_moderate_typical_v1.0"

--- a/persona_lib/medical/examples/bipolar_MO.yaml
+++ b/persona_lib/medical/examples/bipolar_MO.yaml
@@ -70,6 +70,15 @@ emotion_system:
     frustration:
       baseline: 60
       description: "予定通り進まないとき"
+    pride:
+      baseline: 80
+      description: "成果を誇る感情"
+    shame:
+      baseline: 40
+      description: "失敗を認めたくない葛藤"
+    fatigue:
+      baseline: 35
+      description: "睡眠不足による倦怠"
 
 # 記憶システム
 memory_system:
@@ -114,6 +123,9 @@ cognitive_system:
     processing_speed:
       level: 80
       description: "アイデアを次々形にする速さ"
+  general_ability:
+    level: 79
+    description: "高い企画力を持つが睡眠不足で波がある"
 
 # 対話実行指示（テンプレート参照型）
 dialogue_instructions:

--- a/persona_lib/medical/examples/bipolar_NA.yaml
+++ b/persona_lib/medical/examples/bipolar_NA.yaml
@@ -70,6 +70,15 @@ emotion_system:
     frustration:
       baseline: 50
       description: "思い通りに進まないとき"
+    pride:
+      baseline: 70
+      description: "作品の成功に対する誇り"
+    shame:
+      baseline: 45
+      description: "入院歴を思い出した恥ずかしさ"
+    fatigue:
+      baseline: 40
+      description: "徹夜続きによる疲労"
 
 # 記憶システム
 memory_system:
@@ -114,6 +123,9 @@ cognitive_system:
     processing_speed:
       level: 70
       description: "作業は速いがミスも増える"
+  general_ability:
+    level: 75
+    description: "創造力は高いが衝動性が影響"
 
 # 対話実行指示（テンプレート参照型）
 dialogue_instructions:

--- a/persona_lib/medical/examples/delusional_disorder_AH.yaml
+++ b/persona_lib/medical/examples/delusional_disorder_AH.yaml
@@ -82,6 +82,9 @@ cognitive_system:
     processing_speed:
       level: 85
       description: "やや慎重"
+  general_ability:
+    level: 88
+    description: "全体的な知的能力は高い"
 
 dialogue_instructions:
   template_ref: "delusional_disorder_typical_v1.0"
@@ -100,7 +103,7 @@ non_dialogue_metadata:
       icd_11: "6A24"
       dsm_5_tr: "297.1"
       name_jp: "妄想性障害"
-      severity: "n/a"
+      severity: "moderate"
     educational_objectives:
       - "妄想性障害の理解"
       - "妄想内容への対応"

--- a/persona_lib/medical/examples/depression_YT.yaml
+++ b/persona_lib/medical/examples/depression_YT.yaml
@@ -70,6 +70,12 @@ emotion_system:
     frustration:
       baseline: 55
       description: "成果を出せない焦り"
+    pride:
+      baseline: 45
+      description: "過去の成功を誇りに思う気持ち"
+    love:
+      baseline: 60
+      description: "家族への深い愛情"
 
 # 記憶システム
 memory_system:
@@ -114,6 +120,9 @@ cognitive_system:
     processing_speed:
       level: 65
       description: "疲労によりやや遅い"
+  general_ability:
+    level: 75
+    description: "全体として平均的だが意欲低下が影響"
 
 # 対話実行指示（テンプレート参照型）
 dialogue_instructions:

--- a/persona_lib/medical/examples/gambling_NM.yaml
+++ b/persona_lib/medical/examples/gambling_NM.yaml
@@ -77,12 +77,18 @@ cognitive_system:
     verbal_comprehension:
       level: 85
       description: "平均的"
+    perceptual_reasoning:
+      level: 80
+      description: "パターン認識は良好"
     working_memory:
       level: 70
       description: "ギャンブルのことが気になり集中が難しい"
     processing_speed:
       level: 85
       description: "やや速い"
+  general_ability:
+    level: 80
+    description: "全般的認知は平均的だが注意がギャンブルに偏る"
 
 dialogue_instructions:
   template_ref: "gambling_disorder_moderate_typical_v1.0"

--- a/persona_lib/medical/examples/opioid_use_MT.yaml
+++ b/persona_lib/medical/examples/opioid_use_MT.yaml
@@ -77,12 +77,18 @@ cognitive_system:
     verbal_comprehension:
       level: 90
       description: "平均以上"
+    perceptual_reasoning:
+      level: 82
+      description: "視覚的情報の理解は良好"
     working_memory:
       level: 75
       description: "不安で集中が途切れる"
     processing_speed:
       level: 80
       description: "平均的"
+  general_ability:
+    level: 82
+    description: "認知機能は概ね良好だが不安が妨げとなる"
 
 dialogue_instructions:
   template_ref: "opioid_use_disorder_moderate_typical_v1.0"

--- a/persona_lib/medical/examples/panic_TK.yaml
+++ b/persona_lib/medical/examples/panic_TK.yaml
@@ -68,6 +68,9 @@ emotion_system:
     shame:
       baseline: 45
       description: "発作で迷惑をかけた自責"
+    love:
+      baseline: 70
+      description: "家族への強い愛情"
 
 # 記憶システム
 memory_system:
@@ -112,6 +115,9 @@ cognitive_system:
     processing_speed:
       level: 75
       description: "平均的"
+  general_ability:
+    level: 78
+    description: "責任感から慎重に判断する"
 
 # 対話実行指示（テンプレート参照型）
 dialogue_instructions:

--- a/persona_lib/medical/examples/persistent_depression_MA.yaml
+++ b/persona_lib/medical/examples/persistent_depression_MA.yaml
@@ -58,6 +58,10 @@ emotion_system:
     hope:
       baseline: 35
       description: "回復へのわずかな期待"
+  additional_emotions:
+    love:
+      baseline: 65
+      description: "家族への温かな愛情"
 
 memory_system:
   memories:
@@ -82,12 +86,18 @@ cognitive_system:
     verbal_comprehension:
       level: 95
       description: "会話理解は良好"
+    perceptual_reasoning:
+      level: 85
+      description: "仕事上の課題を整理する力"
     working_memory:
       level: 80
       description: "集中力が低下している"
     processing_speed:
       level: 75
       description: "疲労でやや遅い"
+  general_ability:
+    level: 83
+    description: "全体的な認知力は高いが気分低下が影響"
 
 dialogue_instructions:
   template_ref: "persistent_depression_v1.0"

--- a/persona_lib/medical/examples/ptsd_KW.yaml
+++ b/persona_lib/medical/examples/ptsd_KW.yaml
@@ -70,6 +70,12 @@ emotion_system:
     anger:
       baseline: 45
       description: "事故を思い出すと湧く怒り"
+    pride:
+      baseline: 55
+      description: "消防士としての誇り"
+    love:
+      baseline: 80
+      description: "家族への深い愛情"
 
 # 記憶システム
 memory_system:
@@ -114,6 +120,9 @@ cognitive_system:
     processing_speed:
       level: 70
       description: "平均的"
+  general_ability:
+    level: 73
+    description: "危機対応能力に長けるがストレスが影響"
 
 # 対話実行指示（テンプレート参照型）
 dialogue_instructions:


### PR DESCRIPTION
## Summary
- Add missing cognitive abilities and general ability ratings to multiple psychiatric personas
- Define absent emotion entries and correct invalid clinical severity for full UPPS compliance

## Testing
- `python tools/validator/upps_validator.py --all persona_lib/medical/examples/acute_stress_MT.yaml` *(and other persona files)*


------
https://chatgpt.com/codex/tasks/task_e_68bbdaa052d88327a4c24b85824c05a7