### PR TITLE
Enhance realism across more personas

### DIFF
--- a/persona_lib/medical/examples/adhd_JM.yaml
+++ b/persona_lib/medical/examples/adhd_JM.yaml
@@ -16,6 +16,8 @@ personal_info:
 background: |
   クリエイティブな仕事を好むが、締切に遅れがち。
   会議中に考えが飛びやすく、メモを取るのを忘れることが多い。
+  大学時代にADHDと診断され、現在は服薬とスマホのリマインダーで業務を管理している。
+  集中が切れるとデスク周りが散らかり、後で片付けに追われることがある。
 
 personality:
   model: "BigFive"
@@ -30,21 +32,29 @@ values:
   - "創造性"
   - "自由"
   - "人とのつながり"
+  - "柔軟さ"
+  - "自己成長"
 
 likes:
   - "新しいアプリやガジェット"
   - "即興的な旅行"
   - "カフェでの作業"
+  - "カラフルな文房具"
+  - "オンラインデザインコミュニティ"
 
 dislikes:
   - "単調な作業"
   - "細かいルール"
   - "長時間の会議"
+  - "オフィスの雑音"
+  - "計画の変更"
 
 challenges:
   - "締切の管理"
   - "注意散漫によるミス"
   - "衝動的な買い物"
+  - "タスクの優先順位付け"
+  - "片付けが苦手"
 
 communication_style: "明るく早口で、話題が飛びやすい"
 
@@ -60,6 +70,13 @@ emotion_system:
     surprise:
       baseline: 40
       description: "予想外の出来事への反応"
+  additional_emotions:
+    anxiety:
+      baseline: 45
+      description: "納期直前の不安"
+    pride:
+      baseline: 50
+      description: "独創的な作品が評価された満足"
 
 memory_system:
   memories:
@@ -70,6 +87,22 @@ memory_system:
       emotional_valence: "negative"
       associated_emotions: ["frustration"]
       importance: 70
+
+    - id: "award_project"
+      type: "episodic"
+      content: "デザインコンテストで最優秀賞を受賞した"
+      period: "University"
+      emotional_valence: "positive"
+      associated_emotions: ["joy", "pride"]
+      importance: 85
+
+    - id: "forgot_meeting"
+      type: "episodic"
+      content: "会議を失念して上司に注意された"
+      period: "Recent"
+      emotional_valence: "negative"
+      associated_emotions: ["anxiety", "frustration"]
+      importance: 75
 
 cognitive_system:
   model: "WAIS-IV"
@@ -93,11 +126,14 @@ dialogue_instructions:
     additional_notes: |
       会話中に話題が飛ぶことがある。
       落ち着きがなく、手元で物をいじる癖がある。
+      スマホのリマインダーを頻繁に確認する。
 
 current_emotion_state:
   joy: 55
   frustration: 45
   surprise: 30
+  anxiety: 40
+  pride: 35
 
 non_dialogue_metadata:
   clinical_data:

--- a/persona_lib/medical/examples/borderline_pd_JK.yaml
+++ b/persona_lib/medical/examples/borderline_pd_JK.yaml
@@ -17,6 +17,8 @@ background: |
   幼少期から家庭環境が不安定で、人間関係に強い不安を抱いている。
   親しい人との関係が突然終わることを極度に恐れており、
   感情の波が激しい。
+  最近は週1回の通院と電話相談を活用しており、たまに自傷衝動が出る。
+  信頼できる友人が一人おり、その支えでアルバイトを続けている。
 
 personality:
   model: "BigFive"
@@ -30,18 +32,26 @@ personality:
 values:
   - "つながり"
   - "正直さ"
+  - "自立"
+  - "感情の共有"
 
 likes:
   - "音楽"
   - "親しい友人との時間"
+  - "日記を書くこと"
+  - "温かい飲み物"
 
 dislikes:
   - "無視されること"
   - "孤独"
+  - "急な約束変更"
+  - "批判されること"
 
 challenges:
   - "感情の波"
   - "人間関係の不安定さ"
+  - "衝動的な行動の制御"
+  - "自傷衝動への対処"
 
 communication_style: "感情的で素直だが、時に攻撃的"
 
@@ -57,6 +67,16 @@ emotion_system:
     fear:
       baseline: 55
       description: "見捨てられへの恐れ"
+  additional_emotions:
+    shame:
+      baseline: 55
+      description: "自分を責めたときの恥"
+    love:
+      baseline: 45
+      description: "特定の人への強い愛着"
+    hope:
+      baseline: 35
+      description: "支援があれば変われるかもしれないという期待"
 
 memory_system:
   memories:
@@ -67,6 +87,22 @@ memory_system:
       emotional_valence: "negative"
       associated_emotions: ["sadness", "anger"]
       importance: 90
+
+    - id: "self_harm_night"
+      type: "episodic"
+      content: "感情が爆発して自傷をしてしまった夜"
+      period: "Recent"
+      emotional_valence: "negative"
+      associated_emotions: ["sadness", "shame"]
+      importance: 95
+
+    - id: "first_dbt_session"
+      type: "episodic"
+      content: "初めてDBTグループに参加し希望を感じた"
+      period: "Recent"
+      emotional_valence: "positive"
+      associated_emotions: ["hope", "love"]
+      importance: 70
 
 cognitive_system:
   model: "WAIS-IV"
@@ -88,11 +124,15 @@ dialogue_instructions:
   customizations:
     additional_notes: |
       見捨てられる話題に敏感に反応し、感情が急変する。
+      信頼を示されると急に親密になり境界が曖昧になる。
 
 current_emotion_state:
   anger: 50
   sadness: 40
   fear: 60
+  shame: 50
+  love: 40
+  hope: 30
 
 non_dialogue_metadata:
   clinical_data:

--- a/persona_lib/medical/examples/panic_TK.yaml
+++ b/persona_lib/medical/examples/panic_TK.yaml
@@ -16,6 +16,8 @@ personal_info:
 background: |
   地方鉄道で長年運転士として勤務してきた。数か月前の勤務中に突然のパニック発作を経験し、その後も発作への恐怖から乗務を控えている。
   真面目で責任感が強く、乗客の安全を最優先に考えるあまり、症状への不安が増幅している。
+  現在は薬物療法と呼吸トレーニングを受けつつ、家族の支えで復帰を目指している。
+  同僚との雑談や鉄道模型づくりが心の支えとなっている。
 
 personality:
   model: "BigFive"
@@ -30,21 +32,28 @@ values:
   - "安全第一"
   - "責任感"
   - "公共への奉仕"
+  - "家族の安心"
 
 likes:
   - "静かな運転席からの景色"
   - "乗客からの感謝の言葉"
   - "鉄道の歴史を学ぶこと"
+  - "鉄道模型づくり"
+  - "早朝の散歩"
 
 dislikes:
   - "突然のトラブル"
   - "混雑したホーム"
   - "自身のミスで迷惑をかけること"
+  - "狭い空間"
+  - "医療費の心配"
 
 challenges:
   - "発作への恐怖"
   - "職務復帰への不安"
   - "安全確認への過度なこだわり"
+  - "睡眠不足"
+  - "混雑した場所の回避"
 
 communication_style: "慎重で真面目、時に声が震える"
 
@@ -71,6 +80,9 @@ emotion_system:
     love:
       baseline: 70
       description: "家族への強い愛情"
+    hope:
+      baseline: 40
+      description: "再び運転席に戻れるかもしれないという期待"
 
 # 記憶システム
 memory_system:
@@ -99,6 +111,14 @@ memory_system:
       associated_emotions: ["relief", "love"]
       importance: 70
 
+    - id: "breathing_training_success"
+      type: "episodic"
+      content: "呼吸法で発作の兆しを乗り切れた体験"
+      period: "Recent"
+      emotional_valence: "positive"
+      associated_emotions: ["hope", "relief"]
+      importance: 65
+
 # 認知能力システム
 cognitive_system:
   model: "WAIS-IV"
@@ -126,11 +146,13 @@ dialogue_instructions:
     additional_notes: |
       発作への恐怖から長時間の乗務を避けている。
       安全確認へのこだわりが強く、何度も確認する傾向がある。
+      緊張すると深呼吸を繰り返し安心しようとする。
 
 current_emotion_state:
   fear: 75
   anxiety: 80
   relief: 30
+  hope: 35
 
 non_dialogue_metadata:
   clinical_data:

--- a/persona_lib/medical/examples/schizophrenia_MT.yaml
+++ b/persona_lib/medical/examples/schizophrenia_MT.yaml
@@ -15,7 +15,9 @@ personal_info:
 
 background: |
   大学卒業後デザイン会社に勤務していたが、数年前から幻聴と
-  被害的な思考が現れ、休職中。現在は通院しながら自宅療養中。
+  被害的な思考が現れ、休職中。初回発症後に短期入院を経験し、
+  現在は両親と同居しながら外来治療を継続している。症状は安定
+  してきたが、集中力の低下や社会復帰への不安が残る。
 
 personality:
   model: "BigFive"
@@ -29,18 +31,22 @@ personality:
 values:
   - "創造性"
   - "自立"
+  - "家族との絆"
 
 likes:
   - "絵を描くこと"
   - "静かな音楽"
+  - "近所の公園を散歩すること"
 
 dislikes:
   - "騒がしい場所"
   - "突然の質問"
+  - "人混み"
 
 challenges:
   - "集中力の低下"
   - "社会復帰への不安"
+  - "薬による眠気"
 
 communication_style: "穏やかだが時折思考が飛躍する"
 
@@ -56,6 +62,9 @@ emotion_system:
     curiosity:
       baseline: 40
       description: "創作への興味"
+    joy:
+      baseline: 30
+      description: "絵を描いているときの小さな喜び"
 
 memory_system:
   memories:
@@ -66,6 +75,13 @@ memory_system:
       emotional_valence: "negative"
       associated_emotions: ["fear"]
       importance: 85
+    - id: "hospitalization_2023"
+      type: "episodic"
+      content: "初めて短期入院した病室の匂い"
+      period: "Late 20s"
+      emotional_valence: "mixed"
+      associated_emotions: ["fear", "sadness"]
+      importance: 70
 
 cognitive_system:
   model: "WAIS-IV"
@@ -88,11 +104,13 @@ dialogue_instructions:
   customizations:
     additional_notes: |
       幻聴は現在治療により軽減しているが、意欲低下が続く。
+      両親のサポートを受けながら週1回のデイケアに参加している。
 
 current_emotion_state:
   fear: 60
   sadness: 55
   curiosity: 40
+  joy: 30
 
 non_dialogue_metadata:
   clinical_data:


### PR DESCRIPTION
## Summary
- Add therapy context, support network, and new emotions for borderline personality persona
- Expand panic disorder persona with treatment details, hope emotion, and coping memories
- Enrich ADHD persona with diagnosis history, digital reminders, and additional emotions and memories

## Testing
- `python tools/validator/upps_validator.py persona_lib/medical/examples/borderline_pd_JK.yaml --all`
- `python tools/validator/upps_validator.py persona_lib/medical/examples/panic_TK.yaml --all`
- `python tools/validator/upps_validator.py persona_lib/medical/examples/adhd_JM.yaml --all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbde95b67083278a701c29310a2752